### PR TITLE
修复 onebot v11 无法发送图片的bug

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -179,7 +179,7 @@ export function fromSegment(msgList:SegmentElem|SegmentElem[]):MessageElem[]{
     msgList=[].concat(msgList)
     return msgList.map(msg=>{
         const {type,data,...other}=msg
-        return {type,...other,...data} as MessageElem
+        return {...other,...data,type} as MessageElem
     })
 
 }


### PR DESCRIPTION
发送图片时, msg 内容为 
```
{"type": "image", "data": {"file": "base64://iVBIJ...=", "type": null, "cache": "true", "proxy": "true", "timeout": null}}
```
data里也有个type字段，如果把type字段放最前面，后面的 ...data 展开会用 null 覆盖前面的 image, 导致图片发送失败